### PR TITLE
segmentation fault fix

### DIFF
--- a/algorithm_in_c/includes/types.h
+++ b/algorithm_in_c/includes/types.h
@@ -48,7 +48,7 @@ typedef struct colour_count_t
 
 typedef struct step_t
 {
-	char step[3];
+	char step[4];
 } step_t;
 
 typedef struct formula_t

--- a/algorithm_in_c/sources/cube.c
+++ b/algorithm_in_c/sources/cube.c
@@ -85,7 +85,8 @@ void cube_init(void)
 	}
 
 	printf("\n Shuffle cube?[y/n]: ");
-	scanf(" %c", &stub_cube);
+	while ( scanf(" %c", &stub_cube) < 1 )
+	  ;
 
 	if (stub_cube == 'y')
 	{
@@ -2004,7 +2005,7 @@ static void add_formula(char *formula_new, char *description)
 
 static void apply_formula(void)
 {
-	char temp_step[3];
+	char temp_step[4];
 	for (int i = 0; (i < CURRENT_FORMULA.step_count - 1) || (i == 0); i++)
 	{
 

--- a/algorithm_in_c/sources/print.c
+++ b/algorithm_in_c/sources/print.c
@@ -270,7 +270,7 @@ void print_screen(void)
 
 void print_formula(void)
 {
-    char temp_string[17];
+    char temp_string[64];
 
     for (int i = 0; i < formula_count; i++)
     {


### PR DESCRIPTION
fixed a problem with the size of the 'step' structure that
  was causing segmentation faults when 'END\0' was being shoved
  into a 3-byte struct.
expanded print buffer from 17 to 64 to make compiler happy that
  the %d wouldn't expand beyond the buffer
put the scanf in a while loop to make the compiler happy
